### PR TITLE
chore: switch package and source urls to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ About clapper-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/clapper-feedstock/blob/main/LICENSE.txt)
 
-Home: https://gitlab.idiap.ch/software/clapper
+Home: https://github.com/idiap/clapper
 
 Package license: BSD-3-Clause
 
 Summary: Configuration Support for Python Packages and CLIs
 
-Development: https://gitlab.idiap.ch/software/clapper
+Development: https://github.com/idiap/clapper
 
 Documentation: https://clapper.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,9 @@ test:
     - pytest
 
 about:
-  home: https://gitlab.idiap.ch/software/clapper
+  home: https://github.com/idiap/clapper
   doc_url: https://clapper.readthedocs.io
-  dev_url: https://gitlab.idiap.ch/software/clapper
+  dev_url: https://github.com/idiap/clapper
   summary: Configuration Support for Python Packages and CLIs
   license: BSD-3-Clause
   license_file: LICENSES/BSD-3-Clause.txt


### PR DESCRIPTION
Adapt the conda package metadata to the change of place of the repository, from GitLab to [GitHub](https://github.com/idiap/clapper).